### PR TITLE
[ADD] Added missing license to the manifest

### DIFF
--- a/avatax_connector/__manifest__.py
+++ b/avatax_connector/__manifest__.py
@@ -3,7 +3,8 @@
     "name": "Avalara Avatax Connector",
     "version": "1.0",
     "author": "Odoo S.A.",
-    "summary": "Sales tax Calculation",
+    "summary": "Sales tax Calculation",\
+    "license": "GPL-3",
     "description": """
 
 The Avatax module automates the complex task of sales tax calculation with ease.  Sale tax calculations are based on prevalidated shop, warehouse and customer address.  This app plugs into your current installation of odoo with minimal configuration and just works.  Your sales orders, invoices and refunds activity is automatically calculated from Avalara's calc service returning the proper sales tax and places the tax into the order/invoice seamlessly.

--- a/avatax_connector/__manifest__.py
+++ b/avatax_connector/__manifest__.py
@@ -3,7 +3,7 @@
     "name": "Avalara Avatax Connector",
     "version": "1.0",
     "author": "Odoo S.A.",
-    "summary": "Sales tax Calculation",\
+    "summary": "Sales tax Calculation",
     "license": "GPL-3",
     "description": """
 


### PR DESCRIPTION
Avalara tax is GPL-3 module and license is not declared in manifest file so when the module is deployed on Odoo.sh with public repo, it blocks users from deploying module as SH is not able to determine license and it will force them to have private repo only. 

HEre the message users face. 
https://drive.google.com/file/d/1BBxXYckpgiaXC1WAlREaMTkKTbcu8Z-1/view?usp=sharing