### PR TITLE
[FIX] Exemption code is reset when Invoice is created

### DIFF
--- a/avatax_connector/models/account_invoice.py
+++ b/avatax_connector/models/account_invoice.py
@@ -10,8 +10,9 @@ class AccountInvoice(models.Model):
     @api.onchange('partner_id', 'company_id')
     def _onchange_partner_id(self):
         res = super(AccountInvoice, self)._onchange_partner_id()
-        self.exemption_code = self.partner_id.exemption_number or ''
-        self.exemption_code_id = self.partner_id.exemption_code_id.id or None
+        if not self.env.context.get('skip_exemption'):
+            self.exemption_code = self.partner_id.exemption_number or ''
+            self.exemption_code_id = self.partner_id.exemption_code_id.id or None
         if self.partner_id.validation_method:
             self.is_add_validate = True
         else:

--- a/avatax_connector/models/sale_order.py
+++ b/avatax_connector/models/sale_order.py
@@ -21,6 +21,7 @@ class SaleOrder(models.Model):
     @api.multi
     def _prepare_invoice(self):
         invoice_vals = super(SaleOrder, self)._prepare_invoice()
+        self.env.context = frozendict(self.env.context, skip_exemption=True)
         invoice_vals.update({
             'exemption_code': self.exemption_code or '',
             'exemption_code_id': self.exemption_code_id.id or False,


### PR DESCRIPTION
We noticed that when an invoice is created, the Exemption code is changed i.e. the info is not propagated from SO but obtained from Invoice partner of SO.  Thus, we used a context to bypass onchange of partner_id for account.invoice