### PR TITLE
[13.0] fix accounting

### DIFF
--- a/avatax_connector/__manifest__.py
+++ b/avatax_connector/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Avalara Avatax Connector",
-    "version": "13.0.1.0.0",
+    "version": "13.0.2.0.0",
     "author": "Fabrice Henrion, Sodexis"
               ", Open Source Integrators",
     "summary": "Sales tax Calculation",
@@ -40,7 +40,7 @@ This module has Following Features:
         "wizard/avalara_salestax_ping_view.xml",
         "wizard/avalara_salestax_address_validate_view.xml",
         "views/avalara_salestax_view.xml",
-        "views/avalara_salestax_data.xml",
+        "data/avalara_salestax_data.xml",
         "views/partner_view.xml",
         "views/product_view.xml",
         "views/account_move_action.xml",

--- a/avatax_connector/data/avalara_salestax_data.xml
+++ b/avatax_connector/data/avalara_salestax_data.xml
@@ -85,18 +85,16 @@
             <field name="name">Non-Resident</field>
             <field name="code">R</field>
         </record>
-        
+
+        <record id="avatax_tax_group" model="account.tax.group">
+            <field name="name">AvaTax</field>
+       </record>
+
         <record id="avatax" model="account.tax">
                <field name="name">AVATAX</field>
-               <field eval="0.0" name="amount"/>
-                <!-- oldname: type -->
-               <field name="amount_type">percent</field>
-               <!-- <field name="account_collected_id" ref="conf_iva"/>
-               <field name="account_paid_id" ref="conf_iva"/>
-               <field name="base_code_id" ref="tax_code_sales_X"/>
-               <field name="tax_code_id" ref="tax_code_input_X"/>
-               <field name="ref_base_code_id" ref="tax_code_sales_X"/>
-               <field name="ref_tax_code_id" ref="tax_code_input_X"/> -->
+               <field name="tax_group_id" ref="avatax_tax_group"/>
+               <field name="amount_type">fixed</field>
+               <field name="amount" eval="0.01" />
                <field name="type_tax_use">sale</field>
                <field name="is_avatax">True</field>
            </record>

--- a/avatax_connector/models/avalara_salestax.py
+++ b/avatax_connector/models/avalara_salestax.py
@@ -40,8 +40,13 @@ class AvalaraSalestax(models.Model):
         'Account Number', required=True, help="Account Number provided by AvaTax")
     license_key = fields.Char(
         'License Key', required=True, help="License Key provided by AvaTax")
-    service_url = fields.Char('Service URL', default='https://avatax.avalara.net',
-                              required=True, help="The url to connect with")
+    service_url = fields.Selection(
+        [('https://development.avalara.net', 'Test'),
+         ('https://avatax.avalara.net', 'Production')],
+        string='Service URL',
+        default='https://development.avalara.net',
+        required=True,
+        help="The url to connect with")
     date_expiration = fields.Date(
         'Service Expiration Date', readonly=True, help="The expiration date of the service")
     request_timeout = fields.Integer(

--- a/avatax_connector/views/account_tax_view.xml
+++ b/avatax_connector/views/account_tax_view.xml
@@ -7,12 +7,10 @@
             <field name="model">account.tax</field>
             <field name="inherit_id" ref="account.view_tax_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//group/group[2]/field[@name='type_tax_use']" position="after">
+                <field name="description" position="after">
                     <field name="is_avatax"/>
-                </xpath>
+                </field>
             </field>
         </record>
     </data>
 </odoo>
-
- 


### PR DESCRIPTION
Before this, accounting moves for taxes won't be generated.
The solution is to change the AVATAX Tax Code to be a fixed amount.
This requires a forcing a module reinstall, or manually fixing the Tax Code configuration.

In Odoo 13, tax lines with zero value are ignored.
The workaround is to set a default Avatax fixed value of one cent.
See https://github.com/odoo/odoo/blob/13.0/addons/account/models/account_move.py#L561