### PR TITLE
[FIX] Quickfix for get_taxes_values() override, for no Avatax used only

### DIFF
--- a/avatax_connector/__manifest__.py
+++ b/avatax_connector/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Avalara Avatax Connector",
-    "version": "12.0.2.3.1",
+    "version": "12.0.2.3.2",
     "author": "Fabrice Henrion, Sodexis"
               ", Open Source Integrators",
     "summary": "Sales tax Calculation",

--- a/avatax_connector/models/account_invoice.py
+++ b/avatax_connector/models/account_invoice.py
@@ -114,7 +114,9 @@ class AccountInvoice(models.Model):
         tax_grouped = {}
         # avatax charges customers per API call, so don't hit their API in every onchange, only when saving
         contact_avatax = contact_avatax or self.env.context.get('contact_avatax') or avatax_config.enable_immediate_calculation
-        if contact_avatax and self.type in ['out_invoice', 'out_refund']:
+        has_avatax = any(x.tax_id.is_avatax for x in self.tax_line_ids)
+        # TODO don't override get_taxes_values()
+        if contact_avatax and self.type in ['out_invoice', 'out_refund'] and has_avatax:
             avatax_id = account_tax_obj.search(
                 [('is_avatax', '=', True),
                  ('type_tax_use', 'in', ['sale', 'all']),


### PR DESCRIPTION
The case where Avatax and non-Avatax code are is used stills need fixing.