### PR TITLE
[FIX] When a credit on invoice, duplicate the tax amount for line

### DIFF
--- a/avatax_connector/models/account_invoice.py
+++ b/avatax_connector/models/account_invoice.py
@@ -568,13 +568,13 @@ class AccountInvoiceLine(models.Model):
                 line.product_id.tax_code_id.name
                 or line.product_id.categ_id.tax_code_id.name
             )
-            amount = sign * line.quantity * line._get_tax_price_unit()
+            amount = sign * abs(line.quantity) * line._get_tax_price_unit()
             # Calculate discount amount
             discount_amount = 0.0
             is_discounted = False
             if line.discount:
                 discount_amount = (
-                    sign * line.price_unit * line.quantity * line.discount / 100.0
+                    sign * abs(line.quantity) * line.price_unit * line.discount / 100.0
                 )
                 is_discounted = True
             res = {

--- a/avatax_connector/models/account_tax.py
+++ b/avatax_connector/models/account_tax.py
@@ -59,11 +59,6 @@ class AccountTax(models.Model):
                 # Recompute taxes using the configured
                 # taxable price (may differ from price)
                 avatax_amount = avatax_line.tax_amt
-        # Invoices and Credit Notes used unsigned tax amounts
-        # Consider the case where avatax_amount might be None
-        # 2021/04/21: Removed "and abs(avatax_amount)" as this
-        # was causing tax amount duplication on invoices that
-        # have a credit on them
         return avatax_amount
 
     def compute_all(

--- a/avatax_connector/models/account_tax.py
+++ b/avatax_connector/models/account_tax.py
@@ -61,7 +61,10 @@ class AccountTax(models.Model):
                 avatax_amount = avatax_line.tax_amt
         # Invoices and Credit Notes used unsigned tax amounts
         # Consider the case where avatax_amount might be None
-        return avatax_amount and abs(avatax_amount)
+        # 2021/04/21: Removed "and abs(avatax_amount)" as this
+        # was causing tax amount duplication on invoices that
+        # have a credit on them
+        return avatax_amount
 
     def compute_all(
         self, price_unit, currency=None, quantity=1.0, product=None, partner=None


### PR DESCRIPTION
Issue Reported By Customer: When a credit is on the invoice - it duplicated the tax amount for that line item instead of subtracting it. Code fix completed by Hiren Pattani for client repo. Opening PR here to include in base connector.